### PR TITLE
Fix: Update teaching.qmd - Added PSDV and AISG links

### DIFF
--- a/teaching.qmd
+++ b/teaching.qmd
@@ -2,6 +2,9 @@
 title: Teaching
 ---
 
+
+* [Spring 2025 AI for Social Good](https://nipunbatra.github.io/aisg25/)
+* [Spring 2025 Probability, Statistics, and Data Visualization](https://nipunbatra.github.io/psdv25/)
 * [Fall 2024 Machine Learning](https://nipunbatra.github.io/ml2024-fall/)
 * [Spring 2024 Machine Learning](https://nipunbatra.github.io/ml2024/)
 * [Fall 2023 Probabilistic Machine Learning](https://nipunbatra.github.io/pml2023/)


### PR DESCRIPTION
`teaching.qmd`
Added the links to the PSDV and AISG courses' homepage.