### PR TITLE
Tighten desktop homepage spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,8 +175,8 @@
 
     main { overflow: hidden; }
     .container { width: min(var(--container), calc(100% - 48px)); margin: auto; }
-    .hero { padding: 132px 0 76px; }
-    .hero-heading { margin-bottom: 40px; }
+    .hero { padding: 108px 0 48px; }
+    .hero-heading { margin-bottom: 28px; }
     .eyebrow {
       margin: 0 0 10px;
       color: var(--accent);
@@ -193,7 +193,7 @@
       line-height: 0.98;
       letter-spacing: -0.045em;
     }
-    .role-line { margin: 20px 0 0; color: var(--muted); font-size: 1.05rem; }
+    .role-line { margin: 16px 0 0; color: var(--muted); font-size: 1.05rem; }
     .hero-grid {
       display: grid;
       grid-template-columns: minmax(0, 1fr) 296px;
@@ -202,7 +202,7 @@
       align-items: start;
     }
     .bio-content { grid-column: 1; grid-row: 1; }
-    .bio-copy { max-width: 68ch; color: var(--muted); font-size: 1.045rem; line-height: 1.82; }
+    .bio-copy { max-width: 68ch; color: var(--muted); font-size: 1.045rem; line-height: 1.72; }
     .bio-copy p { margin: 18px 0 0; text-wrap: pretty; }
     .bio-copy p:first-child { margin-top: 0; }
     .bio-copy a { color: var(--accent); text-decoration: none; }
@@ -229,7 +229,7 @@
     .profile figcaption { margin-top: 18px; padding-left: 4px; color: var(--muted); font-size: 0.83rem; line-height: 1.55; }
     .profile figcaption strong { display: block; color: var(--ink); font-size: 0.9rem; }
 
-    .social-links { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 28px; }
+    .social-links { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 20px; }
     .social-links a {
       display: inline-flex;
       align-items: center;
@@ -249,14 +249,14 @@
     .social-links a:first-child:hover { color: #fff; background: var(--accent); }
     .social-links a:active { transform: translateY(0) scale(0.98); }
 
-    .section { padding: 88px 0 98px; border-top: 1px solid var(--line); }
+    .section { padding: 46px 0 82px; border-top: 1px solid var(--line); }
     .section-soft { background: var(--paper-soft); }
     .section-heading {
       display: grid;
       grid-template-columns: 0.8fr 1.2fr;
       gap: 52px;
       align-items: end;
-      margin-bottom: 42px;
+      margin-bottom: 28px;
     }
     .section-heading h2 { margin: 0; font-size: clamp(2rem, 4vw, 3rem); font-weight: 500; letter-spacing: -0.025em; }
     .section-heading p { max-width: 56ch; margin: 0; color: var(--muted); font-size: 0.98rem; }
@@ -301,24 +301,24 @@
       grid-template-columns: 1fr auto;
       grid-column: 1 / -1;
       grid-row: 2;
-      gap: 40px;
+      gap: 28px;
       align-items: center;
-      margin: 28px 0 0;
-      padding: 30px 34px;
+      margin: 18px 0 0;
+      padding: 20px 26px;
       border: 1px solid var(--line);
       border-left: 4px solid var(--accent);
       border-radius: 12px;
       background: var(--paper);
     }
-    .lab-cta h2 { margin: 0 0 5px; font-size: 1.45rem; font-weight: 500; }
-    .lab-cta p { margin: 0; color: var(--muted); }
+    .lab-cta h2 { margin: 0 0 3px; font-size: 1.32rem; font-weight: 500; }
+    .lab-cta p { margin: 0; color: var(--muted); font-size: 0.92rem; line-height: 1.5; }
     .cta-actions { display: flex; gap: 10px; }
     .button {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-height: 44px;
-      padding: 10px 17px;
+      min-height: 40px;
+      padding: 8px 14px;
       border: 1px solid var(--line);
       border-radius: 8px;
       font-size: 0.82rem;
@@ -373,7 +373,7 @@
       .lab-cta { order: 3; }
       .profile figcaption { display: none; }
       .bio-copy { font-size: 0.97rem; line-height: 1.78; }
-      .social-links { gap: 7px; }
+      .social-links { gap: 7px; margin-top: 28px; }
       .social-links a { padding: 7px 10px; }
       .section { padding: 64px 0 72px; }
       .section-heading { grid-template-columns: 1fr; gap: 14px; margin-bottom: 30px; }
@@ -383,6 +383,7 @@
       .lab-cta h2 { font-size: 1.32rem; }
       .lab-cta p { font-size: 0.93rem; line-height: 1.62; }
       .cta-actions { flex-wrap: wrap; }
+      .button { min-height: 44px; padding: 10px 17px; }
     }
 
     @keyframes rise-in {


### PR DESCRIPTION
## What changed

- Tightened desktop hero padding and typography spacing.
- Reduced the lab CTA height while preserving its prominence.
- Reduced the space before the conversation section and its cards.
- Kept the existing phone spacing, touch targets, and content order unchanged.

## Why

The desktop layout used more vertical space than necessary, requiring substantial scrolling before the video conversations appeared.

## Validation

- At 1440 × 1000, both video thumbnails are visible without scrolling.
- The 390 × 844 phone layout remains unchanged in structure and readability.
- Rendered and visually inspected directly from the repository checkout.
- `git diff --check origin/main...HEAD` passed.
